### PR TITLE
記事タップ後にWebページへ遷移する処理を実装

### DIFF
--- a/app/src/main/java/net/k2o_info/qiitaview/view/fragment/ArticleListFragment.kt
+++ b/app/src/main/java/net/k2o_info/qiitaview/view/fragment/ArticleListFragment.kt
@@ -2,8 +2,11 @@ package net.k2o_info.qiitaview.view.fragment
 
 import android.content.Context
 import android.databinding.DataBindingUtil
+import android.net.Uri
 import android.os.Bundle
+import android.support.customtabs.CustomTabsIntent
 import android.support.v4.app.Fragment
+import android.support.v4.content.ContextCompat
 import android.support.v4.widget.SwipeRefreshLayout
 import android.support.v7.widget.DividerItemDecoration
 import android.support.v7.widget.LinearLayoutManager
@@ -22,7 +25,7 @@ import timber.log.Timber
  * @author katsuya
  * @since 1.0.0
  */
-class ArticleListFragment : Fragment() {
+class ArticleListFragment : Fragment(), ArticleRecyclerAdapter.ArticleRecyclerListener {
 
     companion object {
 
@@ -65,7 +68,7 @@ class ArticleListFragment : Fragment() {
         recyclerView.addItemDecoration(dividerItemDecoration)
 
         // アダプターを設定
-        val recyclerAdapter = ArticleRecyclerAdapter(context!!)
+        val recyclerAdapter = ArticleRecyclerAdapter(context!!, this)
         recyclerView.adapter = recyclerAdapter
 
         // スワイプダウン時のリフレッシュ処理
@@ -85,6 +88,21 @@ class ArticleListFragment : Fragment() {
      */
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
+    }
+
+    /**
+     * 記事タップ時に呼ばれる
+     *
+     * @param view タップしたビュー
+     * @param position 要素番号
+     */
+    override fun onRecyclerClickedListener(view: View, position: Int) {
+        // タップした記事のURLへ遷移
+        val tabsIntent = CustomTabsIntent.Builder()
+                .setShowTitle(true)
+                .setToolbarColor(ContextCompat.getColor(context!!, R.color.colorPrimary))
+                .build()
+        tabsIntent.launchUrl(context!!, Uri.parse("https://qiita.com/"))
     }
 
 }

--- a/app/src/main/java/net/k2o_info/qiitaview/view/ui/ArticleRecyclerAdapter.kt
+++ b/app/src/main/java/net/k2o_info/qiitaview/view/ui/ArticleRecyclerAdapter.kt
@@ -3,15 +3,22 @@ package net.k2o_info.qiitaview.view.ui
 import android.content.Context
 import android.support.v7.widget.RecyclerView
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import net.k2o_info.qiitaview.R
+import timber.log.Timber
 import java.util.*
 
-class ArticleRecyclerAdapter(context: Context) : RecyclerView.Adapter<ViewHolder>() {
+class ArticleRecyclerAdapter(context: Context, listener: ArticleRecyclerListener) : RecyclerView.Adapter<ViewHolder>() {
 
-    private var inflater: LayoutInflater = LayoutInflater.from(context)
-    private var context: Context = context
+    private val inflater: LayoutInflater = LayoutInflater.from(context)
+    private val context: Context = context
+    private val listener: ArticleRecyclerListener = listener
     private var articleList: List<String> = Arrays.asList("sampleA", "sampleB")//emptyList()
+
+    interface ArticleRecyclerListener {
+        fun onRecyclerClickedListener(view: View, position: Int)
+    }
 
     /**
      * 新規ViewHolderが渡されたときに呼ばれる
@@ -32,6 +39,11 @@ class ArticleRecyclerAdapter(context: Context) : RecyclerView.Adapter<ViewHolder
      */
     override fun onBindViewHolder(viewHolder: ViewHolder, position: Int) {
 
+        // タップ時の処理
+        viewHolder.getView().setOnClickListener{
+            Timber.d("Article of position $position is clicked")
+            listener.onRecyclerClickedListener(it, position)
+        }
     }
 
     /**

--- a/app/src/main/res/layout/article_item.xml
+++ b/app/src/main/res/layout/article_item.xml
@@ -5,7 +5,8 @@
 
     <android.support.constraint.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:foreground="?attr/selectableItemBackground">
 
         <com.makeramen.roundedimageview.RoundedImageView
             android:id="@+id/profile_image"


### PR DESCRIPTION
## 概要

* ArticleLIst要素のタップイベントを追加
* タップイベント後 ChromeCustomeTabでWebページへ遷移する処理を実装

## 関連するIssue

ArticleList要素からWebページへ遷移 #3