### PR TITLE
タグ別記事詳細ページ遷移時にクエリパラメータを渡す処理を実装

### DIFF
--- a/app/src/main/java/net/k2o_info/qiitaview/view/activity/TagDetailActivity.kt
+++ b/app/src/main/java/net/k2o_info/qiitaview/view/activity/TagDetailActivity.kt
@@ -17,7 +17,8 @@ import net.k2o_info.qiitaview.view.fragment.ArticleListFragment
 class TagDetailActivity : AppCompatActivity() {
 
     companion object {
-        public const val TITLE_TAG_ID = "tag_id"
+        const val TITLE_TAG_ID = "tag_id"
+        const val QUERY_PREFIX = "tag:"
     }
 
     /**
@@ -41,7 +42,7 @@ class TagDetailActivity : AppCompatActivity() {
         }
 
         // 記事リストのフラグメントを設定
-        val articleListFragment = ArticleListFragment()
+        val articleListFragment = ArticleListFragment.newInstance(QUERY_PREFIX + title)
         val transaction = supportFragmentManager.beginTransaction()
         transaction.replace(binding.fragmentContainer.id, articleListFragment)
         transaction.commit()

--- a/app/src/main/java/net/k2o_info/qiitaview/view/fragment/ArticleListFragment.kt
+++ b/app/src/main/java/net/k2o_info/qiitaview/view/fragment/ArticleListFragment.kt
@@ -1,5 +1,6 @@
 package net.k2o_info.qiitaview.view.fragment
 
+import android.app.Application
 import android.arch.lifecycle.Observer
 import android.arch.lifecycle.ViewModelProviders
 import android.content.Context
@@ -16,6 +17,7 @@ import android.support.v7.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import net.k2o_info.qiitaview.MainApplication
 import net.k2o_info.qiitaview.R
 import net.k2o_info.qiitaview.databinding.FragmentArticleListBinding
 import net.k2o_info.qiitaview.model.pojo.QiitaArticle
@@ -33,13 +35,19 @@ class ArticleListFragment : Fragment(), ArticleRecyclerAdapter.ArticleRecyclerLi
 
     companion object {
 
+        const val KEY_TAG_QUERY = "tag_qeury"
+
         /**
          * インスタンスの生成
          *
          * @return フラグメント
          */
-        fun newInstance(): ArticleListFragment {
-            return ArticleListFragment()
+        fun newInstance(query: String?): ArticleListFragment {
+            val articleListFragment = ArticleListFragment()
+            val bundle = Bundle()
+            bundle.putString(KEY_TAG_QUERY, query)
+            articleListFragment.arguments = bundle
+            return articleListFragment
         }
 
     }
@@ -75,8 +83,17 @@ class ArticleListFragment : Fragment(), ArticleRecyclerAdapter.ArticleRecyclerLi
         val recyclerAdapter = ArticleRecyclerAdapter(context!!, this)
         recyclerView.adapter = recyclerAdapter
 
+        // クエリを取得
+        val bundle = arguments
+        var query: String? = null
+        if (bundle != null) {
+            query = bundle.getString(KEY_TAG_QUERY)
+        }
+
         // ViewModelの設定
-        val viewModel = ViewModelProviders.of(this).get(ArticleListViewModel::class.java)
+        val viewModel = ViewModelProviders
+                .of(this, ArticleListViewModel.Factory(MainApplication.getInstance() as Application, query))
+                .get(ArticleListViewModel::class.java)
         viewModel.getArticleList().observe(this, Observer { list: List<QiitaArticle>? ->
 
             // リストの更新があった場合にrecyclerAdapterをアップデート

--- a/app/src/main/java/net/k2o_info/qiitaview/viewmodel/fragment/ArticleListViewModel.kt
+++ b/app/src/main/java/net/k2o_info/qiitaview/viewmodel/fragment/ArticleListViewModel.kt
@@ -6,26 +6,35 @@ import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.MutableLiveData
 import net.k2o_info.qiitaview.model.AppRepository
 import net.k2o_info.qiitaview.model.pojo.QiitaArticle
+import android.arch.lifecycle.ViewModel
+import android.arch.lifecycle.ViewModelProvider
 
-class ArticleListViewModel(application: Application): AndroidViewModel(application) {
+
+
+class ArticleListViewModel(application: Application, query: String?): AndroidViewModel(application) {
+
+    companion object {
+        const val DEFAULT_PAGE     = 1
+        const val DEFAULT_PER_PAGE = 50
+    }
 
     private val appRepository: AppRepository = AppRepository.getInstance(application)
+    private val query: String? = query
     private val mutableArticleList: MutableLiveData<List<QiitaArticle>> = MutableLiveData()
     private var articleList: LiveData<List<QiitaArticle>>
-
 
     /**
      * コンストラクタ
      */
     init {
-        articleList = appRepository.getArticle(mutableArticleList, 1, 40, null)
+        articleList = appRepository.getArticle(mutableArticleList, DEFAULT_PAGE, DEFAULT_PER_PAGE, this.query)
     }
 
     /**
      * 記事リストをリフレッシュ
      */
     fun refreshArticleList() {
-        articleList = appRepository.getArticle(mutableArticleList, 1, 40, null)
+        articleList = appRepository.getArticle(mutableArticleList, DEFAULT_PAGE, DEFAULT_PER_PAGE, this.query)
     }
 
     /**
@@ -36,5 +45,17 @@ class ArticleListViewModel(application: Application): AndroidViewModel(applicati
     fun getArticleList(): LiveData<List<QiitaArticle>> {
         return articleList
     }
+
+    class Factory(application: Application, query: String?) : ViewModelProvider.NewInstanceFactory() {
+
+        private val application: Application = application
+        private val query: String? = query
+
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return ArticleListViewModel(application, query) as T
+        }
+
+    }
+
 
 }


### PR DESCRIPTION
## 概要

* ViewModelに queryパラメータを渡す
* タグ詳細ページへ遷移時にタグ別の記事リストを表示

## 関連するIssue

タグ別記事詳細ページの実装漏れ対応 #21